### PR TITLE
v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-**Visionary URL** is a lightweight library for generating image URLs with embedded placeholder data (image dimensions, background color, blurhash).
+**Visionary URL** is a lightweight Typescript library for generating image URLs with built-in Blurhash placeholders.
+
+![NPM version](https://img.shields.io/npm/v/visionary-url?style=flat-square&color=528987) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/visionary-cloud/visionary-url/.github%2Fworkflows%2Fci-cd-workflow.yml?branch=master&style=flat-square)
+ ![NPM bundle size](https://img.shields.io/bundlephobia/min/visionary-url?style=flat-square&color=blue)
+
 
 
 ## Getting started

--- a/lib/visionary-url.ts
+++ b/lib/visionary-url.ts
@@ -9,4 +9,9 @@ export {
   isBase64UrlFormatted,
   suggestedBlurhashComponentDimensions,
 } from "../src/util";
-export * from "../src/types/visionary.types";
+export type {
+  VisionaryImage,
+  VisionaryImageFields,
+  VisionaryImageOptions,
+  VisionaryUrlOptions,
+} from "../src/types/visionary.types";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "visionary-url",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "visionary-url",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "universal-base64url": "1.1.0"
@@ -18,9 +18,9 @@
         "eslint": "8.57.0",
         "rimraf": "5.0.5",
         "typescript": "5.3.3",
-        "vite": "5.1.5",
+        "vite": "5.2.2",
         "vite-plugin-dts": "3.7.3",
-        "vitest": "1.3.1"
+        "vitest": "1.4.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -44,10 +44,26 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
-      "integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "cpu": [
         "arm"
       ],
@@ -61,9 +77,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
-      "integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +93,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
-      "integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +109,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz",
-      "integrity": "sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +125,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
-      "integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "cpu": [
         "x64"
       ],
@@ -125,9 +141,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
-      "integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "cpu": [
         "arm64"
       ],
@@ -141,9 +157,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
-      "integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +173,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
-      "integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "cpu": [
         "arm"
       ],
@@ -173,9 +189,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
-      "integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "cpu": [
         "arm64"
       ],
@@ -189,9 +205,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
-      "integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "cpu": [
         "ia32"
       ],
@@ -205,9 +221,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
-      "integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "cpu": [
         "loong64"
       ],
@@ -221,9 +237,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
-      "integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "cpu": [
         "mips64el"
       ],
@@ -237,9 +253,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
-      "integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "cpu": [
         "ppc64"
       ],
@@ -253,9 +269,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
-      "integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "cpu": [
         "riscv64"
       ],
@@ -269,9 +285,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
-      "integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "cpu": [
         "s390x"
       ],
@@ -285,9 +301,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
-      "integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "cpu": [
         "x64"
       ],
@@ -301,9 +317,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
-      "integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "cpu": [
         "x64"
       ],
@@ -317,9 +333,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
-      "integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "cpu": [
         "x64"
       ],
@@ -333,9 +349,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
-      "integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "cpu": [
         "x64"
       ],
@@ -349,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
-      "integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "cpu": [
         "arm64"
       ],
@@ -365,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
-      "integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "cpu": [
         "ia32"
       ],
@@ -381,9 +397,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
-      "integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -697,9 +713,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.1.tgz",
-      "integrity": "sha512-0WQ0ouLejaUCRsL93GD4uft3rOmB8qoQMU05Kb8CmMtMBe7XUDLAltxVZI1q6byNqEtU7N1ZX1Vw5lIpgulLQA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
+      "integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
       "cpu": [
         "arm"
       ],
@@ -710,9 +726,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.1.tgz",
-      "integrity": "sha512-1TKm25Rn20vr5aTGGZqo6E4mzPicCUD79k17EgTLAsXc1zysyi4xXKACfUbwyANEPAEIxkzwue6JZ+stYzWUTA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
+      "integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
       "cpu": [
         "arm64"
       ],
@@ -723,9 +739,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.1.tgz",
-      "integrity": "sha512-cEXJQY/ZqMACb+nxzDeX9IPLAg7S94xouJJCNVE5BJM8JUEP4HeTF+ti3cmxWeSJo+5D+o8Tc0UAWUkfENdeyw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
+      "integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
       "cpu": [
         "arm64"
       ],
@@ -736,9 +752,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.1.tgz",
-      "integrity": "sha512-LoSU9Xu56isrkV2jLldcKspJ7sSXmZWkAxg7sW/RfF7GS4F5/v4EiqKSMCFbZtDu2Nc1gxxFdQdKwkKS4rwxNg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
+      "integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
       "cpu": [
         "x64"
       ],
@@ -749,9 +765,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.1.tgz",
-      "integrity": "sha512-EfI3hzYAy5vFNDqpXsNxXcgRDcFHUWSx5nnRSCKwXuQlI5J9dD84g2Usw81n3FLBNsGCegKGwwTVsSKK9cooSQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
+      "integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
       "cpu": [
         "arm"
       ],
@@ -762,9 +778,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.1.tgz",
-      "integrity": "sha512-9lhc4UZstsegbNLhH0Zu6TqvDfmhGzuCWtcTFXY10VjLLUe4Mr0Ye2L3rrtHaDd/J5+tFMEuo5LTCSCMXWfUKw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
+      "integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
       "cpu": [
         "arm64"
       ],
@@ -775,9 +791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.1.tgz",
-      "integrity": "sha512-FfoOK1yP5ksX3wwZ4Zk1NgyGHZyuRhf99j64I5oEmirV8EFT7+OhUZEnP+x17lcP/QHJNWGsoJwrz4PJ9fBEXw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
+      "integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
       "cpu": [
         "arm64"
       ],
@@ -787,10 +803,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
+      "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
-      "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
+      "integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
       "cpu": [
         "x64"
       ],
@@ -801,9 +830,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.1.tgz",
-      "integrity": "sha512-RkJVNVRM+piYy87HrKmhbexCHg3A6Z6MU0W9GHnJwBQNBeyhCJG9KDce4SAMdicQnpURggSvtbGo9xAWOfSvIQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
+      "integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
       "cpu": [
         "x64"
       ],
@@ -814,9 +843,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.1.tgz",
-      "integrity": "sha512-v2FVT6xfnnmTe3W9bJXl6r5KwJglMK/iRlkKiIFfO6ysKs0rDgz7Cwwf3tjldxQUrHL9INT/1r4VA0n9L/F1vQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
+      "integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
       "cpu": [
         "arm64"
       ],
@@ -827,9 +856,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.1.tgz",
-      "integrity": "sha512-YEeOjxRyEjqcWphH9dyLbzgkF8wZSKAKUkldRY6dgNR5oKs2LZazqGB41cWJ4Iqqcy9/zqYgmzBkRoVz3Q9MLw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
+      "integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
       "cpu": [
         "ia32"
       ],
@@ -840,9 +869,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.1.tgz",
-      "integrity": "sha512-0zfTlFAIhgz8V2G8STq8toAjsYYA6eci1hnXuyOTUFnymrtJwnS6uGKiv3v5UrPZkBlamLvrLV2iiaeqCKzb0A==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
+      "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
       "cpu": [
         "x64"
       ],
@@ -1133,13 +1162,13 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.1.tgz",
-      "integrity": "sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.4.0.tgz",
+      "integrity": "sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.3.1",
-        "@vitest/utils": "1.3.1",
+        "@vitest/spy": "1.4.0",
+        "@vitest/utils": "1.4.0",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -1147,12 +1176,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.3.1.tgz",
-      "integrity": "sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.4.0.tgz",
+      "integrity": "sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.3.1",
+        "@vitest/utils": "1.4.0",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -1161,9 +1190,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.3.1.tgz",
-      "integrity": "sha512-EF++BZbt6RZmOlE3SuTPu/NfwBF6q4ABS37HHXzs2LUVPBLx2QoY/K0fKpRChSo8eLiuxcbCVfqKgx/dplCDuQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.4.0.tgz",
+      "integrity": "sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -1175,9 +1204,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.1.tgz",
-      "integrity": "sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.4.0.tgz",
+      "integrity": "sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -1187,9 +1216,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.1.tgz",
-      "integrity": "sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.4.0.tgz",
+      "integrity": "sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -1644,9 +1673,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.8.tgz",
-      "integrity": "sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1656,28 +1685,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.19.8",
-        "@esbuild/android-arm64": "0.19.8",
-        "@esbuild/android-x64": "0.19.8",
-        "@esbuild/darwin-arm64": "0.19.8",
-        "@esbuild/darwin-x64": "0.19.8",
-        "@esbuild/freebsd-arm64": "0.19.8",
-        "@esbuild/freebsd-x64": "0.19.8",
-        "@esbuild/linux-arm": "0.19.8",
-        "@esbuild/linux-arm64": "0.19.8",
-        "@esbuild/linux-ia32": "0.19.8",
-        "@esbuild/linux-loong64": "0.19.8",
-        "@esbuild/linux-mips64el": "0.19.8",
-        "@esbuild/linux-ppc64": "0.19.8",
-        "@esbuild/linux-riscv64": "0.19.8",
-        "@esbuild/linux-s390x": "0.19.8",
-        "@esbuild/linux-x64": "0.19.8",
-        "@esbuild/netbsd-x64": "0.19.8",
-        "@esbuild/openbsd-x64": "0.19.8",
-        "@esbuild/sunos-x64": "0.19.8",
-        "@esbuild/win32-arm64": "0.19.8",
-        "@esbuild/win32-ia32": "0.19.8",
-        "@esbuild/win32-x64": "0.19.8"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "node_modules/eslint": {
@@ -2973,9 +3003,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "dev": true,
       "funding": [
         {
@@ -2994,7 +3024,7 @@
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -3113,10 +3143,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
-      "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
+      "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
       "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -3125,18 +3158,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.6.1",
-        "@rollup/rollup-android-arm64": "4.6.1",
-        "@rollup/rollup-darwin-arm64": "4.6.1",
-        "@rollup/rollup-darwin-x64": "4.6.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.6.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.6.1",
-        "@rollup/rollup-linux-arm64-musl": "4.6.1",
-        "@rollup/rollup-linux-x64-gnu": "4.6.1",
-        "@rollup/rollup-linux-x64-musl": "4.6.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.6.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.6.1",
-        "@rollup/rollup-win32-x64-msvc": "4.6.1",
+        "@rollup/rollup-android-arm-eabi": "4.13.0",
+        "@rollup/rollup-android-arm64": "4.13.0",
+        "@rollup/rollup-darwin-arm64": "4.13.0",
+        "@rollup/rollup-darwin-x64": "4.13.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.13.0",
+        "@rollup/rollup-linux-arm64-musl": "4.13.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
+        "@rollup/rollup-linux-x64-gnu": "4.13.0",
+        "@rollup/rollup-linux-x64-musl": "4.13.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.13.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.13.0",
+        "@rollup/rollup-win32-x64-msvc": "4.13.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -3248,9 +3282,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3586,14 +3620,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.2.tgz",
+      "integrity": "sha512-FWZbz0oSdLq5snUI0b6sULbz58iXFXdvkZfZWR/F0ZJuKTSPO7v72QPXt6KqYeMFb0yytNp6kZosxJ96Nr/wDQ==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.19.3",
-        "postcss": "^8.4.35",
-        "rollup": "^4.2.0"
+        "esbuild": "^0.20.1",
+        "postcss": "^8.4.36",
+        "rollup": "^4.13.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3641,9 +3675,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.3.1.tgz",
-      "integrity": "sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.4.0.tgz",
+      "integrity": "sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -3689,16 +3723,16 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.3.1.tgz",
-      "integrity": "sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.4.0.tgz",
+      "integrity": "sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.3.1",
-        "@vitest/runner": "1.3.1",
-        "@vitest/snapshot": "1.3.1",
-        "@vitest/spy": "1.3.1",
-        "@vitest/utils": "1.3.1",
+        "@vitest/expect": "1.4.0",
+        "@vitest/runner": "1.4.0",
+        "@vitest/snapshot": "1.4.0",
+        "@vitest/spy": "1.4.0",
+        "@vitest/utils": "1.4.0",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -3712,7 +3746,7 @@
         "tinybench": "^2.5.1",
         "tinypool": "^0.8.2",
         "vite": "^5.0.0",
-        "vite-node": "1.3.1",
+        "vite-node": "1.4.0",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -3727,8 +3761,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.3.1",
-        "@vitest/ui": "1.3.1",
+        "@vitest/browser": "1.4.0",
+        "@vitest/ui": "1.4.0",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "eslint": "8.57.0",
     "rimraf": "5.0.5",
     "typescript": "5.3.3",
-    "vite": "5.1.5",
+    "vite": "5.2.2",
     "vite-plugin-dts": "3.7.3",
-    "vitest": "1.3.1"
+    "vitest": "1.4.0"
   },
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visionary-url",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "A lightweight library for generating image URLs with baked-in blurhash placeholders.",
   "type": "module",
   "main": "./dist/visionary-url.cjs",

--- a/src/__test__/image-options.test.ts
+++ b/src/__test__/image-options.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { ImageFormatToken, ImageSizeToken } from "../enum";
 import { generateOptionsString, parseOptionsString } from "../image-options";
-import { ImageOptions } from "../types/visionary.types";
+import { VisionaryImageOptions } from "../types/visionary.types";
 
 describe(parseOptionsString.name, () => {
   test("parses an options string with size and format specified", () => {
@@ -75,8 +75,8 @@ describe(generateOptionsString.name, () => {
   });
 
   test("does not return options string for invalid options", () => {
-    expect(generateOptionsString(null as unknown as ImageOptions)).toBeNull();
-    expect(generateOptionsString("" as unknown as ImageOptions)).toBeNull();
-    expect(generateOptionsString({ notAnOption: true } as unknown as ImageOptions)).toBeNull();
+    expect(generateOptionsString(null as unknown as VisionaryImageOptions)).toBeNull();
+    expect(generateOptionsString("" as unknown as VisionaryImageOptions)).toBeNull();
+    expect(generateOptionsString({ notAnOption: true } as unknown as VisionaryImageOptions)).toBeNull();
   });
 });

--- a/src/__test__/image-options.test.ts
+++ b/src/__test__/image-options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { ImageFormatEnum, ImageSizeEnum } from "../enum";
+import { ImageFormatToken, ImageSizeToken } from "../enum";
 import { generateOptionsString, parseOptionsString } from "../image-options";
 import { ImageOptions } from "../types/visionary.types";
 
@@ -10,7 +10,7 @@ describe(parseOptionsString.name, () => {
 
     const parsedOptions = parseOptionsString(optionsString);
 
-    expect(parsedOptions.size).toBe(ImageSizeEnum.xs);
+    expect(parsedOptions.size).toBe(ImageSizeToken.xs);
   });
 
   test("tests a size token (lg)", () => {
@@ -18,7 +18,7 @@ describe(parseOptionsString.name, () => {
 
     const parsedOptions = parseOptionsString(optionsString);
 
-    expect(parsedOptions.size).toBe(ImageSizeEnum.lg);
+    expect(parsedOptions.size).toBe(ImageSizeToken.lg);
   });
 
   test("parses an options string with debug set", () => {
@@ -27,7 +27,7 @@ describe(parseOptionsString.name, () => {
     const parsedOptions = parseOptionsString(optionsString);
 
     expect(parsedOptions.debug).toBe(true);
-    expect(parsedOptions.size).toBe(ImageSizeEnum.xl);
+    expect(parsedOptions.size).toBe(ImageSizeToken.xl);
   });
 
   test("parses an options string with download set", () => {
@@ -36,7 +36,7 @@ describe(parseOptionsString.name, () => {
     const parsedOptions = parseOptionsString(optionsString);
 
     expect(parsedOptions.download).toBe(true);
-    expect(parsedOptions.size).toBe(ImageSizeEnum["4k"]);
+    expect(parsedOptions.size).toBe(ImageSizeToken["4k"]);
   });
 
   test("parses an options string with format set", () => {
@@ -59,16 +59,16 @@ describe(generateOptionsString.name, () => {
   test("generates a sorted options string from options", () => {
     const optionsString1 = generateOptionsString({
       download: true,
-      format: ImageFormatEnum.WEBP,
-      size: ImageSizeEnum.sm,
+      format: ImageFormatToken.WEBP,
+      size: ImageSizeToken.sm,
     });
 
     expect(optionsString1).toBe("download,sm,webp");
 
     const optionsString2 = generateOptionsString({
       debug: true,
-      format: ImageFormatEnum.AVIF,
-      size: ImageSizeEnum["5k"],
+      format: ImageFormatToken.AVIF,
+      size: ImageSizeToken["5k"],
     });
 
     expect(optionsString2).toBe("5k,avif,debug");

--- a/src/__test__/util.test.ts
+++ b/src/__test__/util.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { ImageFormatToken } from "../enum";
-import { isImageSizeToken, tokenizeOptionsString } from "../token";
+import { isImageSizeToken, tokeni } from "../token";
 import {
   compact,
   suggestedBlurhashComponentDimensions,
@@ -49,16 +49,6 @@ describe("Visionary URL utils", () => {
     test("returns false for invalid base64url values", () => {
       expect(isBase64UrlFormatted("YmFzZQ==")).toBe(false);
       expect(isBase64UrlFormatted("invalid!")).toBe(false);
-    });
-  });
-
-  describe(tokenizeOptionsString.name, () => {
-    test("can tokenize an options string", () => {
-      const optionsString = "debug,xl";
-
-      const tokens = tokenizeOptionsString(optionsString);
-
-      expect(tokens).toEqual(["debug", "xl"]);
     });
   });
 

--- a/src/__test__/util.test.ts
+++ b/src/__test__/util.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { ImageFormatEnum } from "../enum";
+import { ImageFormatToken } from "../enum";
 import { isImageSizeToken, tokenizeOptionsString } from "../token";
 import {
   compact,
@@ -27,14 +27,14 @@ describe("Visionary URL utils", () => {
 
   describe(formatToContentType.name, () => {
     test("returns proper content type", () => {
-      const result = formatToContentType(ImageFormatEnum.JPEG);
+      const result = formatToContentType(ImageFormatToken.JPEG);
 
       expect(result.contentType).toBe("image/jpeg");
     });
 
     test("throws on unknown format", () => {
       expect(() => {
-        formatToContentType("haha" as ImageFormatEnum);
+        formatToContentType("haha" as ImageFormatToken);
       }).toThrow(/unknown format/);
     });
   });

--- a/src/__test__/util.test.ts
+++ b/src/__test__/util.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { ImageFormatToken } from "../enum";
-import { isImageSizeToken, tokeni } from "../token";
+import { isImageSizeToken } from "../token";
 import {
   compact,
   suggestedBlurhashComponentDimensions,

--- a/src/__test__/visionary-url.test.ts
+++ b/src/__test__/visionary-url.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { VisionaryImageFields } from "../types/visionary.types";
-import { ImageFormatEnum, ImageSizeEnum } from "../enum";
+import { ImageFormatToken, ImageSizeToken } from "../enum";
 import { InvalidEndpoint } from "../error";
 import { generateVisionaryUrl, parseVisionaryString, parseVisionaryUrl } from "../visionary-url";
 
@@ -34,8 +34,8 @@ describe("visionary-url", () => {
       const { fields, options } = parseVisionaryUrl(urlWithOptions)!;
 
       expect(fields.fileId).toBe("vb87s1");
-      expect(options.size).toBe(ImageSizeEnum["4k"]);
-      expect(options.format).toBe(ImageFormatEnum.AVIF);
+      expect(options.size).toBe(ImageSizeToken["4k"]);
+      expect(options.format).toBe(ImageFormatToken.AVIF);
       expect(Object.keys(options).length).toBe(2);
     });
 
@@ -81,7 +81,7 @@ describe("visionary-url", () => {
     test("generates a URL with image options", () => {
       const url = generateVisionaryUrl(sampleFields, {
         download: true,
-        size: ImageSizeEnum.full,
+        size: ImageSizeToken.full,
       });
 
       const expectedUrl =
@@ -94,7 +94,7 @@ describe("visionary-url", () => {
       const url = generateVisionaryUrl(sampleFields, {
         download: true,
         filename: "flowers.jpg",
-        size: ImageSizeEnum["4k"],
+        size: ImageSizeToken["4k"],
       });
 
       const expectedUrl =
@@ -158,8 +158,8 @@ describe("visionary-url", () => {
       const { fields, options } = parseVisionaryString(inputString)!;
 
       expect(fields.fileId).toBe("vb87s1");
-      expect(options.size).toBe(ImageSizeEnum["sm"]);
-      expect(options.format).toBe(ImageFormatEnum.WEBP);
+      expect(options.size).toBe(ImageSizeToken["sm"]);
+      expect(options.format).toBe(ImageFormatToken.WEBP);
     });
 
     test("parses a Visionary code", () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { ImageFormatEnum, ImageSizeEnum } from "./enum";
+import { ImageFormatToken, ImageSizeToken } from "./enum";
 import { ImageOptions } from "./types/visionary.types";
 
 /**
@@ -14,35 +14,35 @@ export const CDN_ENDPOINT = "https://cdn.visionary.cloud";
 
 export const DEFAULT_OPTIONS: ImageOptions = {
   debug: false,
-  format: ImageFormatEnum.AUTO,
-  size: ImageSizeEnum.lg,
+  format: ImageFormatToken.AUTO,
+  size: ImageSizeToken.lg,
 };
 
 /**
  * Maps bootstrap-inspired size codes to pixels
  */
-export const IMAGE_SIZES: Record<ImageSizeEnum, number> = {
-  [ImageSizeEnum.xs]: 160,
-  [ImageSizeEnum.sm]: 320,
-  [ImageSizeEnum.md]: 640,
-  [ImageSizeEnum.lg]: 1280,
-  [ImageSizeEnum.xl]: 1920,
-  [ImageSizeEnum.xxl]: 2560,
-  [ImageSizeEnum["4k"]]: 3840,
-  [ImageSizeEnum["5k"]]: 5120,
-  [ImageSizeEnum.full]: 0,
+export const IMAGE_SIZES: Record<ImageSizeToken, number> = {
+  [ImageSizeToken.xs]: 160,
+  [ImageSizeToken.sm]: 320,
+  [ImageSizeToken.md]: 640,
+  [ImageSizeToken.lg]: 1280,
+  [ImageSizeToken.xl]: 1920,
+  [ImageSizeToken.xxl]: 2560,
+  [ImageSizeToken["4k"]]: 3840,
+  [ImageSizeToken["5k"]]: 5120,
+  [ImageSizeToken.full]: 0,
 };
 
-export const IMAGE_SIZE_LOOKUP: Record<number, ImageSizeEnum> = Object.keys(IMAGE_SIZES).reduce(
+export const IMAGE_SIZE_LOOKUP: Record<number, ImageSizeToken> = Object.keys(IMAGE_SIZES).reduce(
   (obj, key) => {
-    const keyEnum = key as ImageSizeEnum;
+    const keyEnum = key as ImageSizeToken;
     const numericalValue = IMAGE_SIZES[keyEnum];
     if (numericalValue) {
       obj[numericalValue] = keyEnum;
     }
     return obj;
   },
-  {} as Record<number, ImageSizeEnum>
+  {} as Record<number, ImageSizeToken>
 );
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const DEFAULT_OPTIONS: ImageOptions = {
 /**
  * Maps bootstrap-inspired size codes to pixels
  */
-export const IMAGE_SIZES: Partial<Record<ImageSizeEnum, number>> = {
+export const IMAGE_SIZES: Record<ImageSizeEnum, number> = {
   [ImageSizeEnum.xs]: 160,
   [ImageSizeEnum.sm]: 320,
   [ImageSizeEnum.md]: 640,
@@ -30,6 +30,7 @@ export const IMAGE_SIZES: Partial<Record<ImageSizeEnum, number>> = {
   [ImageSizeEnum.xxl]: 2560,
   [ImageSizeEnum["4k"]]: 3840,
   [ImageSizeEnum["5k"]]: 5120,
+  [ImageSizeEnum.full]: 0,
 };
 
 export const IMAGE_SIZE_LOOKUP: Record<number, ImageSizeEnum> = Object.keys(IMAGE_SIZES).reduce(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 import { ImageFormatToken, ImageSizeToken } from "./enum";
-import { ImageOptions } from "./types/visionary.types";
+import { VisionaryImageOptions } from "./types/visionary.types";
 
 /**
  * Defaults blurhash components to [4, 4] (or [4, 3] for landscape photos)
@@ -12,7 +12,7 @@ export const BASE_BLURHASH_DIMENSIONS = 4;
  */
 export const CDN_ENDPOINT = "https://cdn.visionary.cloud";
 
-export const DEFAULT_OPTIONS: ImageOptions = {
+export const DEFAULT_OPTIONS: VisionaryImageOptions = {
   debug: false,
   format: ImageFormatToken.AUTO,
   size: ImageSizeToken.lg,

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -14,6 +14,9 @@ export enum ImageSizeEnum {
   xxl = "xxl",
   "4k" = "4k",
   "5k" = "5k",
+  /**
+   * `full` is image dependent and represents the source image's longest edge
+   */
   full = "full",
 }
 

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -1,11 +1,11 @@
-export enum ImageFormatEnum {
+export enum ImageFormatToken {
   AUTO = "auto",
   AVIF = "avif",
   JPEG = "jpeg",
   WEBP = "webp",
 }
 
-export enum ImageSizeEnum {
+export enum ImageSizeToken {
   xs = "xs",
   sm = "sm",
   md = "md",
@@ -20,7 +20,8 @@ export enum ImageSizeEnum {
   full = "full",
 }
 
-export enum ImageTokenEnum {
+//  - not to be confused with `VisionaryUrlOptions` taken via generateVisionaryUrl
+export enum UrlOptionToken {
   DEBUG = "debug",
   DOWNLOAD = "download",
 }

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -20,7 +20,6 @@ export enum ImageSizeToken {
   full = "full",
 }
 
-//  - not to be confused with `VisionaryUrlOptions` taken via generateVisionaryUrl
 export enum UrlOptionToken {
   DEBUG = "debug",
   DOWNLOAD = "download",

--- a/src/image-options.ts
+++ b/src/image-options.ts
@@ -1,4 +1,4 @@
-import { ImageFormatEnum, ImageSizeEnum, ImageTokenEnum } from "./enum";
+import { ImageFormatToken, ImageSizeToken, UrlOptionToken } from "./enum";
 import { isDebugToken, isDownloadToken, isFormatString, isImageSizeToken } from "./token";
 import { ImageOptions } from "./types/visionary.types";
 
@@ -8,7 +8,7 @@ export const parseOptionTokens = (optionTokens: string[] = []): ImageOptions => 
   const returnOptions: ImageOptions = {};
   for (const token of optionTokens) {
     if (isImageSizeToken(token)) {
-      returnOptions.size = ImageSizeEnum[token];
+      returnOptions.size = ImageSizeToken[token];
     } else if (isDebugToken(token)) {
       returnOptions.debug = true;
     } else if (isDownloadToken(token)) {
@@ -24,15 +24,15 @@ export const generateOptionsString = (options: ImageOptions): string | null => {
   if (!options || typeof options !== "object") {
     return null;
   }
-  const tokenArr: Array<ImageTokenEnum | ImageFormatEnum | ImageSizeEnum> = [];
+  const tokenArr: Array<ImageFormatToken | ImageSizeToken | UrlOptionToken> = [];
   if (options.debug) {
-    tokenArr.push(ImageTokenEnum.DEBUG);
+    tokenArr.push(UrlOptionToken.DEBUG);
   }
   if (options.download) {
-    tokenArr.push(ImageTokenEnum.DOWNLOAD);
+    tokenArr.push(UrlOptionToken.DOWNLOAD);
   }
   if (options.format) {
-    if (options.format !== ImageFormatEnum.AUTO) {
+    if (options.format !== ImageFormatToken.AUTO) {
       tokenArr.push(options.format);
     }
   }

--- a/src/image-options.ts
+++ b/src/image-options.ts
@@ -1,11 +1,9 @@
 import { ImageFormatToken, ImageSizeToken, UrlOptionToken } from "./enum";
-import { isDebugToken, isDownloadToken, isFormatString, isImageSizeToken } from "./token";
-import { ImageOptions } from "./types/visionary.types";
+import { isDebugToken, isDownloadToken, isImageFormatToken, isImageSizeToken } from "./token";
+import { VisionaryImageOptions } from "./types/visionary.types";
 
-export const parseOptionsString = (options = ""): ImageOptions => parseOptionTokens(options.split(","));
-
-export const parseOptionTokens = (optionTokens: string[] = []): ImageOptions => {
-  const returnOptions: ImageOptions = {};
+export const parseOptionTokens = (optionTokens: string[] = []): VisionaryImageOptions => {
+  const returnOptions: VisionaryImageOptions = {};
   for (const token of optionTokens) {
     if (isImageSizeToken(token)) {
       returnOptions.size = ImageSizeToken[token];
@@ -13,14 +11,14 @@ export const parseOptionTokens = (optionTokens: string[] = []): ImageOptions => 
       returnOptions.debug = true;
     } else if (isDownloadToken(token)) {
       returnOptions.download = true;
-    } else if (isFormatString(token)) {
+    } else if (isImageFormatToken(token)) {
       returnOptions.format = token;
     }
   }
   return returnOptions;
 };
 
-export const generateOptionsString = (options: ImageOptions): string | null => {
+export const generateOptionsString = (options: VisionaryImageOptions): string | null => {
   if (!options || typeof options !== "object") {
     return null;
   }
@@ -41,3 +39,6 @@ export const generateOptionsString = (options: ImageOptions): string | null => {
   }
   return tokenArr.length ? tokenArr.sort().join(",") : null;
 };
+
+export const parseOptionsString = (options = ""): VisionaryImageOptions =>
+  parseOptionTokens(options.split(","));

--- a/src/token.ts
+++ b/src/token.ts
@@ -4,10 +4,8 @@ export const isDebugToken = (token: string) => token === UrlOptionToken.DEBUG;
 
 export const isDownloadToken = (token: string) => token === UrlOptionToken.DOWNLOAD;
 
-export const isFormatString = (format: string): format is ImageFormatToken =>
+export const isImageFormatToken = (format: string): format is ImageFormatToken =>
   Object.values(ImageFormatToken).includes(format as ImageFormatToken);
 
 export const isImageSizeToken = (token: string): token is ImageSizeToken =>
   Object.values(ImageSizeToken).includes(token as ImageSizeToken);
-
-export const tokenizeOptionsString = (options: string) => options.split(",");

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,13 +1,13 @@
-import { ImageFormatEnum, ImageSizeEnum, ImageTokenEnum } from "./enum";
+import { ImageFormatToken, ImageSizeToken, UrlOptionToken } from "./enum";
 
-export const isDebugToken = (token: string) => token === ImageTokenEnum.DEBUG;
+export const isDebugToken = (token: string) => token === UrlOptionToken.DEBUG;
 
-export const isDownloadToken = (token: string) => token === ImageTokenEnum.DOWNLOAD;
+export const isDownloadToken = (token: string) => token === UrlOptionToken.DOWNLOAD;
 
-export const isFormatString = (format: string): format is ImageFormatEnum =>
-  Object.values(ImageFormatEnum).includes(format as ImageFormatEnum);
+export const isFormatString = (format: string): format is ImageFormatToken =>
+  Object.values(ImageFormatToken).includes(format as ImageFormatToken);
 
-export const isImageSizeToken = (token: string): token is ImageSizeEnum =>
-  Object.values(ImageSizeEnum).includes(token as ImageSizeEnum);
+export const isImageSizeToken = (token: string): token is ImageSizeToken =>
+  Object.values(ImageSizeToken).includes(token as ImageSizeToken);
 
 export const tokenizeOptionsString = (options: string) => options.split(",");

--- a/src/types/visionary.types.ts
+++ b/src/types/visionary.types.ts
@@ -1,4 +1,4 @@
-import { ImageFormatEnum, ImageSizeEnum } from "../enum";
+import { ImageFormatToken, ImageSizeToken } from "../enum";
 
 /**
  * Image metadata fields encoded in a Visionary URL
@@ -67,14 +67,14 @@ export interface ImageOptions {
    * (e.g. content-disposition: attachment)
    */
   download?: boolean;
-  format?: ImageFormatEnum;
-  size?: ImageSizeEnum;
+  format?: ImageFormatToken;
+  size?: ImageSizeToken;
 }
 
 /**
  * Fields passed to generateVisionaryUrl()
  */
-export interface GenerateVisionaryUrlOptions extends ImageOptions {
+export interface VisionaryUrlOptions extends ImageOptions {
   /**
    * Specifies a custom endpoint
    */

--- a/src/types/visionary.types.ts
+++ b/src/types/visionary.types.ts
@@ -53,13 +53,13 @@ export interface VisionaryUrlParts {
 
 export interface VisionaryImage {
   fields: VisionaryImageFields;
-  options: ImageOptions;
+  options: VisionaryImageOptions;
 }
 
 /**
- * Details encoded in the second segment of the URL (after Visionary code)
+ * Details encoded in the second segment of a Visionary URL (after Visionary code)
  */
-export interface ImageOptions {
+export interface VisionaryImageOptions {
   debug?: boolean;
 
   /**
@@ -74,7 +74,7 @@ export interface ImageOptions {
 /**
  * Fields passed to generateVisionaryUrl()
  */
-export interface VisionaryUrlOptions extends ImageOptions {
+export interface VisionaryUrlOptions extends VisionaryImageOptions {
   /**
    * Specifies a custom endpoint
    */

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { BASE_BLURHASH_DIMENSIONS } from "./constants";
-import { ImageFormatEnum } from "./enum";
+import { ImageFormatToken } from "./enum";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const compact = (items: any[]) => items.filter(Boolean);
@@ -12,13 +12,13 @@ export const createUrl = (url: string): URL | null => {
   }
 };
 
-export const formatToContentType = (format: ImageFormatEnum) => {
+export const formatToContentType = (format: ImageFormatToken) => {
   switch (format) {
-    case ImageFormatEnum.AVIF:
+    case ImageFormatToken.AVIF:
       return { contentType: "image/avif", extension: "avif" };
-    case ImageFormatEnum.JPEG:
+    case ImageFormatToken.JPEG:
       return { contentType: "image/jpeg", extension: "jpg" };
-    case ImageFormatEnum.WEBP:
+    case ImageFormatToken.WEBP:
       return { contentType: "image/webp", extension: "webp" };
     default:
       throw new Error(`formatToContentType: unknown format ${format}`);

--- a/src/visionary-url.ts
+++ b/src/visionary-url.ts
@@ -5,7 +5,7 @@ import { compact, createUrl, isBase64UrlFormatted } from "./util";
 import { generateVisionaryCode, parseVisionaryCode } from "./visionary-code";
 
 import {
-  GenerateVisionaryUrlOptions,
+  VisionaryUrlOptions,
   VisionaryImage,
   VisionaryImageFields,
   VisionaryUrlParts,
@@ -64,7 +64,7 @@ export const parseVisionaryUrl = (url: string): VisionaryImage | null => {
 
 export const generateVisionaryUrl = (
   fields: VisionaryImageFields,
-  options?: GenerateVisionaryUrlOptions
+  options?: VisionaryUrlOptions
 ): string | null => {
   const visionaryCode = generateVisionaryCode(fields);
   if (visionaryCode instanceof Error) {


### PR DESCRIPTION
- Refactor enums, types to improve readability
- Add shields to README (npm version, build status, package size)
- update `vite`, `vitest` minor versions
- bump `visionary-url` minor version
- remove unused function `tokenizeOptionsString`