### PR TITLE
[v.1.3.0] rename `fileId` prop to `url`; clean up unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,13 @@ npm-debug.log*
 
 node_modules
 dist
+bin
 *.local
 
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 **Visionary URL** is a lightweight Typescript library for generating image URLs with built-in Blurhash placeholders.
 
 ![NPM version](https://img.shields.io/npm/v/visionary-url?style=flat-square&color=528987) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/visionary-cloud/visionary-url/.github%2Fworkflows%2Fci-cd-workflow.yml?branch=master&style=flat-square)
- ![NPM bundle size](https://img.shields.io/bundlephobia/min/visionary-url?style=flat-square&color=blue)
-
-
+![NPM bundle size](https://img.shields.io/bundlephobia/min/visionary-url?style=flat-square&color=blue)
 
 ## Getting started
 
@@ -16,55 +14,50 @@ npm install --save visionary-url
 ### Generating a Visionary URL
 
 ```javascript
-import { generateVisionaryUrl } from 'visionary-url';
+import { generateVisionaryUrl } from "visionary-url";
 
 const url = generateVisionaryUrl({
   blurhash: "LCDJYN9FxG_M_N%L%M%M4o~ptRIA", // blurhash string
   blurhashX: 4, // blurhash x components
   blurhashY: 4, // blurhash y components
   bcc: "#baccae", // background color code
-  fileId: "image:101", // image ID or URL
   sourceHeight: 1200, // image height
   sourceWidth: 1600, // image width
+  url: "https://example.cdn/media/gato.jpg", // image URL or file ID
 });
 ```
-
-
 
 ## How it works
 
 A Visionary URL is formatted using 3 or 4 URL segments:
-|  | base path | | visionary code | | options (optional) | | filename |
+| | base path | | visionary code | | options (optional) | | filename |
 | -- | -- | -- | -- | -- | -- | -- | -- |
 | `/` | `image` | `/` | `<visionary code, base64url>` | `/` |`<option tokens>` | `/` | `image.jpg` |
 
 ### Example URLs
 
 ```
-https://examplecdn.cloud/image/aW1hZ2U6MTAwMDEhODAwITYwMA/image.jpg
-https://examplecdn.cloud/image/aW1hZ2U6MTAwMDEhODAwITYwMA/4k/image.jpg
+https://example.cdn/image/aW1hZ2U6MTAwMDEhODAwITYwMA/image.jpg
+https://example.cdn/image/aW1hZ2U6MTAwMDEhODAwITYwMA/4k/image.jpg
 ```
 
 ### Visionary code
 
 The **Visionary code** is a base64url'd, exclamation-point separated list of image placeholder data, detailed as the following:
 
-
-| Attribute | Description |
-| -- | -- |
-| Image ID | Image URL or internal image ID (required) |
-| Image width | Used to compute aspect ratio of image placeholder (required) |
-| Image height | Used to compute aspect ratio of image placeholder (required) |
-| Background color code | Base layer background color code (e.g. `#BACCAE`) |
-| Blurhash code | Blurhash string of the image |
-| Blurhash x components | Number of x components the blurhash code represents |
-| Blurhash y components | Number of y components the blurhash code represents |
-
+| Attribute             | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| Image URL / ID        | Image URL or Visionary file ID (required)                    |
+| Image width           | Used to compute aspect ratio of image placeholder (required) |
+| Image height          | Used to compute aspect ratio of image placeholder (required) |
+| Background color code | Base layer background color code (e.g. `#BACCAE`)            |
+| Blurhash code         | Blurhash string of the image                                 |
+| Blurhash x components | Number of x components the blurhash code represents          |
+| Blurhash y components | Number of y components the blurhash code represents          |
 
 ### Image options
 
 Image options are optional and are provided as comma separated tokens.
-
 
 #### Size token
 
@@ -72,9 +65,6 @@ One of the following tokens may be included in the options string to specify an 
 
 #### Download token
 
-| token | description |
-| --  |   --- |
-| `download`  | Indication for server to return `content-disposition: attachment;` in response headers  |
-
-
-
+| token      | description                                                                            |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `download` | Indication for server to return `content-disposition: attachment;` in response headers |

--- a/lib/visionary-url.ts
+++ b/lib/visionary-url.ts
@@ -6,7 +6,7 @@ export { parseOptionsString } from "../src/image-options";
 export * from "../src/token";
 export {
   formatToContentType,
-  isBase64UrlFormatted,
+  isBase64UrlEncoded,
   suggestedBlurhashComponentDimensions,
 } from "../src/util";
 export type {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "visionary-url",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "visionary-url",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "universal-base64url": "1.1.0"
@@ -18,9 +18,9 @@
         "eslint": "8.57.0",
         "rimraf": "5.0.5",
         "typescript": "5.3.3",
-        "vite": "5.2.2",
-        "vite-plugin-dts": "3.7.3",
-        "vitest": "1.4.0"
+        "vite": "5.3.1",
+        "vite-plugin-dts": "3.9.1",
+        "vitest": "1.6.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
       ],
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
       ],
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
       ],
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
       ],
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
       ],
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
       ],
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
       ],
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
       ],
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
       ],
@@ -285,9 +285,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
       ],
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
       ],
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
       ],
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
       ],
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
       ],
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
       ],
@@ -397,9 +397,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
       ],
@@ -581,37 +581,73 @@
       "dev": true
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.39.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.39.0.tgz",
-      "integrity": "sha512-PuXxzadgnvp+wdeZFPonssRAj/EW4Gm4s75TXzPk09h3wJ8RS3x7typf95B4vwZRrPTQBGopdUl+/vHvlPdAcg==",
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.43.0.tgz",
+      "integrity": "sha512-GFhTcJpB+MI6FhvXEI9b2K0snulNLWHqC/BbcJtyNYcKUiw7l3Lgis5ApsYncJ0leALX7/of4XfmXk+maT111w==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.28.3",
+        "@microsoft/api-extractor-model": "7.28.13",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.62.0",
-        "@rushstack/rig-package": "0.5.1",
-        "@rushstack/ts-command-line": "4.17.1",
-        "colors": "~1.2.1",
+        "@rushstack/node-core-library": "4.0.2",
+        "@rushstack/rig-package": "0.5.2",
+        "@rushstack/terminal": "0.10.0",
+        "@rushstack/ts-command-line": "4.19.1",
         "lodash": "~4.17.15",
+        "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
         "semver": "~7.5.4",
         "source-map": "~0.6.1",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.3.tgz",
-      "integrity": "sha512-wT/kB2oDbdZXITyDh2SQLzaWwTOFbV326fP0pUwNW00WeliARs0qjmXBWmGWardEzp2U3/axkO3Lboqun6vrig==",
+      "version": "7.28.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.13.tgz",
+      "integrity": "sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==",
       "dev": true,
       "dependencies": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.62.0"
+        "@rushstack/node-core-library": "4.0.2"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -882,12 +918,11 @@
       ]
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.62.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.62.0.tgz",
-      "integrity": "sha512-88aJn2h8UpSvdwuDXBv1/v1heM6GnBf3RjEy6ZPP7UnzHNCqOHA2Ut+ScYUbXcqIdfew9JlTAe3g+cnX9xQ/Aw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.0.2.tgz",
+      "integrity": "sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==",
       "dev": true,
       "dependencies": {
-        "colors": "~1.2.1",
         "fs-extra": "~7.0.1",
         "import-lazy": "~4.0.0",
         "jju": "~1.4.0",
@@ -905,24 +940,57 @@
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.1.tgz",
-      "integrity": "sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.2.tgz",
+      "integrity": "sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==",
       "dev": true,
       "dependencies": {
         "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
       }
     },
-    "node_modules/@rushstack/ts-command-line": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.17.1.tgz",
-      "integrity": "sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==",
+    "node_modules/@rushstack/terminal": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.10.0.tgz",
+      "integrity": "sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==",
       "dev": true,
       "dependencies": {
+        "@rushstack/node-core-library": "4.0.2",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/terminal/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.19.1.tgz",
+      "integrity": "sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/terminal": "0.10.0",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
-        "colors": "~1.2.1",
         "string-argv": "~0.3.1"
       }
     },
@@ -1162,13 +1230,13 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.4.0.tgz",
-      "integrity": "sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
+      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.4.0",
-        "@vitest/utils": "1.4.0",
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -1176,12 +1244,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.4.0.tgz",
-      "integrity": "sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
+      "integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.4.0",
+        "@vitest/utils": "1.6.0",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -1190,9 +1258,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.4.0.tgz",
-      "integrity": "sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
+      "integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -1204,9 +1272,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.4.0.tgz",
-      "integrity": "sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
+      "integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -1216,9 +1284,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.4.0.tgz",
-      "integrity": "sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -1541,15 +1609,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/colors": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -1610,9 +1669,9 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
@@ -1673,9 +1732,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1685,29 +1744,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/eslint": {
@@ -2291,9 +2350,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2380,12 +2439,15 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2634,15 +2696,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.8",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
-      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/merge-stream": {
@@ -3083,9 +3142,9 @@
       ]
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
     "node_modules/resolve": {
@@ -3492,9 +3551,9 @@
       "dev": true
     },
     "node_modules/tinypool": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.2.tgz",
-      "integrity": "sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -3611,22 +3670,22 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
-      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/vite": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.2.tgz",
-      "integrity": "sha512-FWZbz0oSdLq5snUI0b6sULbz58iXFXdvkZfZWR/F0ZJuKTSPO7v72QPXt6KqYeMFb0yytNp6kZosxJ96Nr/wDQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.1.tgz",
+      "integrity": "sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.20.1",
-        "postcss": "^8.4.36",
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.38",
         "rollup": "^4.13.0"
       },
       "bin": {
@@ -3675,9 +3734,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.4.0.tgz",
-      "integrity": "sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
+      "integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -3697,17 +3756,18 @@
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.7.3.tgz",
-      "integrity": "sha512-26eTlBYdpjRLWCsTJebM8vkCieE+p9gP3raf+ecDnzzK5E3FG6VE1wcy55OkRpfWWVlVvKkYFe6uvRHYWx7Nog==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.9.1.tgz",
+      "integrity": "sha512-rVp2KM9Ue22NGWB8dNtWEr+KekN3rIgz1tWD050QnRGlriUCmaDwa7qA5zDEjbXg5lAXhYMSBJtx3q3hQIJZSg==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor": "7.39.0",
+        "@microsoft/api-extractor": "7.43.0",
         "@rollup/pluginutils": "^5.1.0",
-        "@vue/language-core": "^1.8.26",
+        "@vue/language-core": "^1.8.27",
         "debug": "^4.3.4",
         "kolorist": "^1.8.0",
-        "vue-tsc": "^1.8.26"
+        "magic-string": "^0.30.8",
+        "vue-tsc": "^1.8.27"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -3723,16 +3783,16 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.4.0.tgz",
-      "integrity": "sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
+      "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.4.0",
-        "@vitest/runner": "1.4.0",
-        "@vitest/snapshot": "1.4.0",
-        "@vitest/spy": "1.4.0",
-        "@vitest/utils": "1.4.0",
+        "@vitest/expect": "1.6.0",
+        "@vitest/runner": "1.6.0",
+        "@vitest/snapshot": "1.6.0",
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -3744,9 +3804,9 @@
         "std-env": "^3.5.0",
         "strip-literal": "^2.0.0",
         "tinybench": "^2.5.1",
-        "tinypool": "^0.8.2",
+        "tinypool": "^0.8.3",
         "vite": "^5.0.0",
-        "vite-node": "1.4.0",
+        "vite-node": "1.6.0",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -3761,8 +3821,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.4.0",
-        "@vitest/ui": "1.4.0",
+        "@vitest/browser": "1.6.0",
+        "@vitest/ui": "1.6.0",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "visionary-url",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "visionary-url",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "universal-base64url": "1.1.0"
       },
       "devDependencies": {
         "@types/node": "18.19.2",
-        "@typescript-eslint/eslint-plugin": "7.1.1",
-        "@typescript-eslint/parser": "7.1.1",
+        "@typescript-eslint/eslint-plugin": "7.14.1",
+        "@typescript-eslint/parser": "7.14.1",
         "eslint": "8.57.0",
-        "rimraf": "5.0.5",
-        "typescript": "5.3.3",
+        "rimraf": "5.0.7",
+        "typescript": "5.5.2",
         "vite": "5.3.1",
         "vite-plugin-dts": "3.9.1",
         "vitest": "1.6.0"
@@ -1012,12 +1012,6 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "18.19.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.2.tgz",
@@ -1027,32 +1021,24 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.1.tgz",
-      "integrity": "sha512-zioDz623d0RHNhvx0eesUmGfIjzrk18nSBC8xewepKXbBvN/7c1qImV7Hg8TI1URTxKax7/zxfxj3Uph8Chcuw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.14.1.tgz",
+      "integrity": "sha512-aAJd6bIf2vvQRjUG3ZkNXkmBpN+J7Wd0mfQiiVCJMu9Z5GcZZdcc0j8XwN/BM97Fl7e3SkTXODSk4VehUv7CGw==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/type-utils": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/type-utils": "7.14.1",
+        "@typescript-eslint/utils": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1069,19 +1055,19 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.1.tgz",
-      "integrity": "sha512-ZWUFyL0z04R1nAEgr9e79YtV5LbafdOtN7yapNbn1ansMyaegl2D4bL7vHoJ4HPSc4CaLwuCVas8CVuneKzplQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.14.1.tgz",
+      "integrity": "sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/typescript-estree": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1097,16 +1083,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.1.tgz",
-      "integrity": "sha512-cirZpA8bJMRb4WZ+rO6+mnOJrGFDd38WoXCEI57+CYBqta8Yc8aJym2i7vyqLL1vVYljgw0X27axkUXz32T8TA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.14.1.tgz",
+      "integrity": "sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1"
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1114,18 +1100,18 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.1.tgz",
-      "integrity": "sha512-5r4RKze6XHEEhlZnJtR3GYeCh1IueUHdbrukV2KSlLXaTjuSfeVF8mZUVPLovidCuZfbVjfhi4c0DNSa/Rdg5g==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.14.1.tgz",
+      "integrity": "sha512-/MzmgNd3nnbDbOi3LfasXWWe292+iuo+umJ0bCCMCPc1jLO/z2BQmWUUUXvXLbrQey/JgzdF/OV+I5bzEGwJkQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
+        "@typescript-eslint/typescript-estree": "7.14.1",
+        "@typescript-eslint/utils": "7.14.1",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1141,12 +1127,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.1.tgz",
-      "integrity": "sha512-KhewzrlRMrgeKm1U9bh2z5aoL4s7K3tK5DwHDn8MHv0yQfWFz/0ZR6trrIHHa5CsF83j/GgHqzdbzCXJ3crx0Q==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==",
       "dev": true,
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1154,22 +1140,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.1.tgz",
-      "integrity": "sha512-9ZOncVSfr+sMXVxxca2OJOPagRwT0u/UHikM2Rd6L/aB+kL/QAuTnsv6MeXtjzCJYb8PzrXarypSGIPx3Jemxw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz",
+      "integrity": "sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1181,22 +1167,31 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.1.tgz",
-      "integrity": "sha512-thOXM89xA03xAE0lW7alstvnyoBUbBX38YtY+zAUcpRPcq9EIhXPuJ0YTv948MbzmKh6e1AUszn5cBFK49Umqg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.14.1.tgz",
+      "integrity": "sha512-CMmVVELns3nak3cpJhZosDkm63n+DwBlDX8g0k4QUa9BMnF+lH2lr3d130M1Zt1xxmB3LLk3NV7KQCq86ZBBhQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "semver": "^7.5.4"
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/typescript-estree": "7.14.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1207,16 +1202,16 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.1.tgz",
-      "integrity": "sha512-yTdHDQxY7cSoCcAtiBzVzxleJhkGB9NncSIyMYe2+OGON1ZsP9zOPws/Pqgopa65jvknOjlk/w7ulPlZ78PiLQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz",
+      "integrity": "sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "7.14.1",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1501,12 +1496,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2063,9 +2058,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2720,12 +2715,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -2745,9 +2740,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -3184,9 +3179,9 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.7.tgz",
+      "integrity": "sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==",
       "dev": true,
       "dependencies": {
         "glob": "^10.3.7"
@@ -3195,7 +3190,7 @@
         "rimraf": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3614,9 +3609,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visionary-url",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A lightweight library for generating image URLs with baked-in blurhash placeholders.",
   "type": "module",
   "main": "./dist/visionary-url.cjs",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "eslint": "8.57.0",
     "rimraf": "5.0.5",
     "typescript": "5.3.3",
-    "vite": "5.2.2",
-    "vite-plugin-dts": "3.7.3",
-    "vitest": "1.4.0"
+    "vite": "5.3.1",
+    "vite-plugin-dts": "3.9.1",
+    "vitest": "1.6.0"
   },
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visionary-url",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A lightweight library for generating image URLs with baked-in blurhash placeholders.",
   "type": "module",
   "main": "./dist/visionary-url.cjs",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
   },
   "devDependencies": {
     "@types/node": "18.19.2",
-    "@typescript-eslint/eslint-plugin": "7.1.1",
-    "@typescript-eslint/parser": "7.1.1",
+    "@typescript-eslint/eslint-plugin": "7.14.1",
+    "@typescript-eslint/parser": "7.14.1",
     "eslint": "8.57.0",
-    "rimraf": "5.0.5",
-    "typescript": "5.3.3",
+    "rimraf": "5.0.7",
+    "typescript": "5.5.2",
     "vite": "5.3.1",
     "vite-plugin-dts": "3.9.1",
     "vitest": "1.6.0"

--- a/src/__test__/util.test.ts
+++ b/src/__test__/util.test.ts
@@ -6,7 +6,7 @@ import {
   compact,
   suggestedBlurhashComponentDimensions,
   formatToContentType,
-  isBase64UrlFormatted,
+  isBase64UrlEncoded,
   extractBlurhashComponentDimensions,
 } from "../util";
 
@@ -39,16 +39,16 @@ describe("Visionary URL utils", () => {
     });
   });
 
-  describe(isBase64UrlFormatted.name, () => {
+  describe(isBase64UrlEncoded.name, () => {
     test("returns true for valid base64url values", () => {
-      expect(isBase64UrlFormatted("dmlzaW9uYXJ5")).toBe(true);
+      expect(isBase64UrlEncoded("dmlzaW9uYXJ5")).toBe(true);
 
-      expect(isBase64UrlFormatted("dGhpcyBpcyBhIHZhbGlkIGJhc2U2NHVybCB2YWx1ZSBzaXI")).toBe(true);
+      expect(isBase64UrlEncoded("dGhpcyBpcyBhIHZhbGlkIGJhc2U2NHVybCB2YWx1ZSBzaXI")).toBe(true);
     });
 
     test("returns false for invalid base64url values", () => {
-      expect(isBase64UrlFormatted("YmFzZQ==")).toBe(false);
-      expect(isBase64UrlFormatted("invalid!")).toBe(false);
+      expect(isBase64UrlEncoded("YmFzZQ==")).toBe(false);
+      expect(isBase64UrlEncoded("invalid!")).toBe(false);
     });
   });
 

--- a/src/__test__/visionary-code.test.ts
+++ b/src/__test__/visionary-code.test.ts
@@ -11,22 +11,22 @@ describe("visionary-code", () => {
    * parseVisionaryCode
    */
   describe(parseVisionaryCode.name, () => {
-    test("parses a barebones code with fileId and image dimensions", () => {
+    test("parses a barebones code with url and image dimensions only", () => {
       const code = "aW1hZ2U6MTAwMDEhODAwITYwMA";
 
       const fields = parseVisionaryCode(code);
 
-      expect(fields?.fileId).toBe("image:10001");
+      expect(fields?.url).toBe("image:10001");
       expect(fields?.sourceWidth).toBe(800);
       expect(fields?.sourceHeight).toBe(600);
     });
 
-    test("parses a code with fileId, image dimensions, and background color code", () => {
+    test("parses a code with url, image dimensions, and background color code", () => {
       const code = "aW1hZ2U6MTAwMDEhODAwITYwMCEjQkVFRUVG";
 
       const fields = parseVisionaryCode(code);
 
-      expect(fields?.fileId).toBe("image:10001");
+      expect(fields?.url).toBe("image:10001");
       expect(fields?.sourceWidth).toBe(800);
       expect(fields?.sourceHeight).toBe(600);
       expect(fields?.bcc).toBe("#BEEEEF");
@@ -37,7 +37,7 @@ describe("visionary-code", () => {
 
       const fields = parseVisionaryCode(code);
 
-      expect(fields?.fileId).toBe("image:10001");
+      expect(fields?.url).toBe("image:10001");
       expect(fields?.sourceWidth).toBe(800);
       expect(fields?.sourceHeight).toBe(600);
       expect(fields?.bcc).toBe("#BEEEEF");
@@ -46,7 +46,7 @@ describe("visionary-code", () => {
       expect(fields?.blurhashY).toBe(4);
     });
 
-    test("parses a code with a URL as fileId", () => {
+    test("parses a code containing a URL", () => {
       const code =
         "aHR0cDovL2kuaW1hZ2VjZG40Mi5zcGFjZS9wdWJsaWMvaW1hZ2UtMTEuanBnITQzMiE2NDEhI2JhY2NhZSFCT0JnOV5-cS07fnE_Ynh1ITMhMg";
 
@@ -54,7 +54,7 @@ describe("visionary-code", () => {
 
       expect(fields?.sourceWidth).toBe(432);
       expect(fields?.bcc).toBe("#baccae");
-      expect(fields?.fileId).toBe("http://i.imagecdn42.space/public/image-11.jpg");
+      expect(fields?.url).toBe("http://i.imagecdn42.space/public/image-11.jpg");
       expect(fields?.blurhash).toBe("BOBg9^~q-;~q?bxu");
       expect(fields?.blurhashX).toBe(3);
       expect(fields?.blurhashY).toBe(2);
@@ -84,9 +84,9 @@ describe("visionary-code", () => {
         blurhash: "blurhashvalllue",
         blurhashX: 4,
         blurhashY: 3,
-        fileId: "jk92",
         sourceHeight: 100,
         sourceWidth: 200,
+        url: "jk92",
       };
 
       const code = generateVisionaryCode(fields);
@@ -103,9 +103,9 @@ describe("visionary-code", () => {
         blurhashX: 3,
         blurhashY: 3,
         bcc: "be3e3f",
-        fileId: "jk93",
         sourceHeight: 100,
         sourceWidth: 100,
+        url: "jk93",
       };
 
       const code = generateVisionaryCode(fields);
@@ -118,13 +118,13 @@ describe("visionary-code", () => {
 
     test("generates a barebones code (with only imageId and dimensions)", () => {
       const fields: VisionaryImageFields = {
-        fileId: "42",
         sourceHeight: 300,
         sourceWidth: 300,
+        url: "42",
       };
 
       const expectedVisionaryCode = encodeBase64Url(
-        [fields.fileId, fields.sourceWidth, fields.sourceHeight].join(V_CODE_SEPARATOR)
+        [fields.url, fields.sourceWidth, fields.sourceHeight].join(V_CODE_SEPARATOR)
       );
 
       const visionaryCode = generateVisionaryCode(fields);
@@ -135,9 +135,9 @@ describe("visionary-code", () => {
     test("generates a code with imageId, dimensions, and bcc (no blurhash)", () => {
       const fields: VisionaryImageFields = {
         bcc: "ff6699",
-        fileId: "42",
         sourceHeight: 300,
         sourceWidth: 300,
+        url: "42",
       };
 
       const visionaryCode = generateVisionaryCode(fields);

--- a/src/__test__/visionary-code.test.ts
+++ b/src/__test__/visionary-code.test.ts
@@ -12,16 +12,16 @@ describe("visionary-code", () => {
    */
   describe(parseVisionaryCode.name, () => {
     test("parses a barebones code with url and image dimensions only", () => {
-      const code = "aW1hZ2U6MTAwMDEhODAwITYwMA";
+      const code = "cE1uOVohODAwITYwMA";
 
       const fields = parseVisionaryCode(code);
 
-      expect(fields?.url).toBe("image:10001");
+      expect(fields?.url).toBe("pMn9Z");
       expect(fields?.sourceWidth).toBe(800);
       expect(fields?.sourceHeight).toBe(600);
     });
 
-    test("parses a code with url, image dimensions, and background color code", () => {
+    test("parses a code with image dimensions and background color code", () => {
       const code = "aW1hZ2U6MTAwMDEhODAwITYwMCEjQkVFRUVG";
 
       const fields = parseVisionaryCode(code);
@@ -32,7 +32,7 @@ describe("visionary-code", () => {
       expect(fields?.bcc).toBe("#BEEEEF");
     });
 
-    test("parses a full visionary code", () => {
+    test("parses a full visionary code with fileId as url", () => {
       const code = "aW1hZ2U6MTAwMDEhODAwITYwMCEjQkVFRUVGIVRDTSpCYl4rUmt4dXh1YWd-cVdDaj9Ne017ZmohMyE0";
 
       const fields = parseVisionaryCode(code);
@@ -60,8 +60,8 @@ describe("visionary-code", () => {
       expect(fields?.blurhashY).toBe(2);
     });
 
-    test("ignores a bad code", () => {
-      const badCode = "haha~~not-a-code!";
+    test("ignores an invalid code", () => {
+      const badCode = "haha~~not~~valid!";
 
       const test = parseVisionaryCode(badCode);
 
@@ -81,17 +81,17 @@ describe("visionary-code", () => {
     test("generates a code", () => {
       const fields: VisionaryImageFields = {
         bcc: "be3e3f",
-        blurhash: "blurhashvalllue",
-        blurhashX: 4,
-        blurhashY: 3,
+        blurhash: "18D+9+}S",
+        blurhashX: 2,
+        blurhashY: 1,
         sourceHeight: 100,
         sourceWidth: 200,
-        url: "jk92",
+        url: "NdCJU",
       };
 
       const code = generateVisionaryCode(fields);
 
-      const expectedCode = "ams5MiEyMDAhMTAwIWJlM2UzZiFibHVyaGFzaHZhbGxsdWUhNCEz";
+      const expectedCode = "TmRDSlUhMjAwITEwMCFiZTNlM2YhMThEKzkrfVMhMiEx";
 
       expect(code).toBe(expectedCode);
     });
@@ -99,24 +99,23 @@ describe("visionary-code", () => {
     test("generates a code with alt text", () => {
       const fields: VisionaryImageFields = {
         altText: "Happy cow on a farm",
-        blurhash: "blurhashvalllue",
-        blurhashX: 3,
-        blurhashY: 3,
+        blurhash: "A8D+9+}S01S$",
+        blurhashX: 2,
+        blurhashY: 2,
         bcc: "be3e3f",
         sourceHeight: 100,
         sourceWidth: 100,
-        url: "jk93",
+        url: "I2zUw",
       };
 
       const code = generateVisionaryCode(fields);
 
-      const expectedCode =
-        "ams5MyExMDAhMTAwIWJlM2UzZiFibHVyaGFzaHZhbGxsdWUhMyEzIUhhcHB5IGNvdyBvbiBhIGZhcm0";
+      const expectedCode = "STJ6VXchMTAwITEwMCFiZTNlM2YhQThEKzkrfVMwMVMkITIhMiFIYXBweSBjb3cgb24gYSBmYXJt";
 
       expect(code).toBe(expectedCode);
     });
 
-    test("generates a barebones code (with only imageId and dimensions)", () => {
+    test("generates a barebones code (with only url/fileId and dimensions)", () => {
       const fields: VisionaryImageFields = {
         sourceHeight: 300,
         sourceWidth: 300,
@@ -132,7 +131,7 @@ describe("visionary-code", () => {
       expect(visionaryCode).toBe(expectedVisionaryCode);
     });
 
-    test("generates a code with imageId, dimensions, and bcc (no blurhash)", () => {
+    test("generates a code with fileId as url, dimensions, and bcc (no blurhash)", () => {
       const fields: VisionaryImageFields = {
         bcc: "ff6699",
         sourceHeight: 300,

--- a/src/__test__/visionary-url.test.ts
+++ b/src/__test__/visionary-url.test.ts
@@ -10,9 +10,9 @@ const sampleFields: VisionaryImageFields = {
   blurhashX: 4,
   blurhashY: 4,
   bcc: "110044",
-  fileId: "vb87s1",
   sourceHeight: 1200,
   sourceWidth: 1600,
+  url: "vb87s1",
 };
 
 const sampleUrl =
@@ -23,7 +23,7 @@ describe("visionary-url", () => {
     test("parses a Visionary URL", () => {
       const { fields, options } = parseVisionaryUrl(sampleUrl)!;
 
-      expect(fields.fileId).toBe("vb87s1");
+      expect(fields.url).toBe("vb87s1");
       expect(Object.keys(options).length).toBe(0);
     });
 
@@ -33,7 +33,7 @@ describe("visionary-url", () => {
 
       const { fields, options } = parseVisionaryUrl(urlWithOptions)!;
 
-      expect(fields.fileId).toBe("vb87s1");
+      expect(fields.url).toBe("vb87s1");
       expect(options.size).toBe(ImageSizeToken["4k"]);
       expect(options.format).toBe(ImageFormatToken.AVIF);
       expect(Object.keys(options).length).toBe(2);
@@ -114,9 +114,9 @@ describe("visionary-url", () => {
       expect(url).toBe(expectedUrl);
     });
 
-    test("generates a URL with only fileId/width/height (no bg color or blurhash)", () => {
+    test("generates a URL with only url/width/height (no bg color or blurhash)", () => {
       const url = generateVisionaryUrl({
-        fileId: "https://iss.space/earth.jpg",
+        url: "https://iss.space/earth.jpg",
         sourceWidth: 400,
         sourceHeight: 300,
       });
@@ -157,7 +157,7 @@ describe("visionary-url", () => {
 
       const { fields, options } = parseVisionaryString(inputString)!;
 
-      expect(fields.fileId).toBe("vb87s1");
+      expect(fields.url).toBe("vb87s1");
       expect(options.size).toBe(ImageSizeToken["sm"]);
       expect(options.format).toBe(ImageFormatToken.WEBP);
     });
@@ -168,7 +168,7 @@ describe("visionary-url", () => {
 
       const { fields } = parseVisionaryString(inputString)!;
 
-      expect(fields.fileId).toBe("FzHyI1RXO2");
+      expect(fields.url).toBe("FzHyI1RXO2");
       expect(fields.bcc).toBe("d3be80");
       expect(fields.blurhashX).toBe(4);
       expect(fields.blurhashY).toBe(4);

--- a/src/types/visionary.types.ts
+++ b/src/types/visionary.types.ts
@@ -44,6 +44,12 @@ export interface VisionaryImageFields {
    * Width of original upload image (also max width)
    */
   sourceWidth: number;
+
+  /**
+   * Image source URL or Visionary code
+   *
+   */
+  src: string;
 }
 
 export interface VisionaryUrlParts {
@@ -57,7 +63,7 @@ export interface VisionaryImage {
 }
 
 /**
- * Details encoded in the second segment of a Visionary URL (after Visionary code)
+ * Options are encoded in the second segment of a Visionary URL
  */
 export interface VisionaryImageOptions {
   debug?: boolean;

--- a/src/types/visionary.types.ts
+++ b/src/types/visionary.types.ts
@@ -46,7 +46,7 @@ export interface VisionaryImageFields {
   sourceWidth: number;
 
   /**
-   * Image source URL or Visionary code
+   * Image URL or Visionary code
    *
    */
   src: string;

--- a/src/types/visionary.types.ts
+++ b/src/types/visionary.types.ts
@@ -31,11 +31,6 @@ export interface VisionaryImageFields {
   blurhashY?: number;
 
   /**
-   * Visionary File ID or Image URL
-   */
-  fileId: string;
-
-  /**
    * Height of original upload image (also max height)
    */
   sourceHeight: number;
@@ -46,10 +41,9 @@ export interface VisionaryImageFields {
   sourceWidth: number;
 
   /**
-   * Image URL or Visionary code
-   *
+   * Image URL or Visionary File ID
    */
-  src: string;
+  url: string;
 }
 
 export interface VisionaryUrlParts {

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,7 @@ export const formatToContentType = (format: ImageFormatToken) => {
   }
 };
 
-export const isBase64UrlFormatted = (str = "") => /^[A-Za-z0-9_-]*$/.test(str);
+export const isBase64UrlEncoded = (str = "") => /^[A-Za-z0-9_-]*$/.test(str);
 
 /**
  * This is purposely kept simple as sometimes cranking these values up results in a good image, other times not.

--- a/src/visionary-code.ts
+++ b/src/visionary-code.ts
@@ -9,12 +9,12 @@ import { VisionaryImageFields } from "./types/visionary.types";
  * Generates a Visionary image code
  */
 export const generateVisionaryCode = (fields: VisionaryImageFields): string | Error => {
-  const { altText, bcc, blurhash, blurhashX, blurhashY, fileId, sourceHeight, sourceWidth } = fields;
-  if (!fileId || !sourceWidth || !sourceHeight) {
-    return new Error("Cannot construct visionary code: missing required fileId/width/height");
+  const { altText, bcc, blurhash, blurhashX, blurhashY, sourceHeight, sourceWidth, url } = fields;
+  if (!url || !sourceWidth || !sourceHeight) {
+    return new Error("Cannot construct visionary code: missing required url/width/height");
   }
   // minimum needed image placeholder information
-  const visionaryComponents = [fileId, sourceWidth, sourceHeight];
+  const visionaryComponents = [url, sourceWidth, sourceHeight];
   if (!bcc) {
     return joinAndEncodeComponents(visionaryComponents);
   }
@@ -48,13 +48,13 @@ export const parseVisionaryCode = (code: string): VisionaryImageFields | null =>
     return null;
   }
   const imageData = imageDataStr.split(V_CODE_SEPARATOR);
-  // codes must contain at a minimum: fileId, width, height
+  // codes must contain at a minimum: url, width, height
   if (imageData.length < 3) {
     return null;
   }
-  const [fileIdInput, widthInput, heightInput, bcc, blurhash, bhX, bhY, altText] = imageData;
-  const fileId = fileIdInput.trim();
-  if (!fileId.length) {
+  const [urlInput, widthInput, heightInput, bcc, blurhash, bhX, bhY, altText] = imageData;
+  const url = urlInput.trim();
+  if (!url.length) {
     console.error("Cannot parse code, empty file id");
     return null;
   }
@@ -76,9 +76,9 @@ export const parseVisionaryCode = (code: string): VisionaryImageFields | null =>
     blurhash,
     blurhashX,
     blurhashY,
-    fileId,
     sourceHeight,
     sourceWidth,
+    url,
   };
   return fields;
 };

--- a/src/visionary-code.ts
+++ b/src/visionary-code.ts
@@ -1,7 +1,7 @@
 import { decode as decodeBase64Url, encode as encodeBase64Url } from "universal-base64url";
 
 import { V_CODE_SEPARATOR } from "./constants";
-import { isBase64UrlFormatted } from "./util";
+import { isBase64UrlEncoded } from "./util";
 
 import { VisionaryImageFields } from "./types/visionary.types";
 
@@ -40,14 +40,13 @@ export const parseVisionaryCode = (code: string): VisionaryImageFields | null =>
     return null;
   }
   const sanitizedCode = code.trim();
-  if (!sanitizedCode.length || !isBase64UrlFormatted(sanitizedCode)) {
+  if (!sanitizedCode.length || !isBase64UrlEncoded(sanitizedCode)) {
     return null;
   }
   const imageDataStr = decodeBase64Url(sanitizedCode);
   if (!imageDataStr) {
     return null;
   }
-  // const fields = imageData.split(V_CODE_SEPARATOR);
   const imageData = imageDataStr.split(V_CODE_SEPARATOR);
   // codes must contain at a minimum: fileId, width, height
   if (imageData.length < 3) {

--- a/src/visionary-url.ts
+++ b/src/visionary-url.ts
@@ -1,7 +1,7 @@
 import { CDN_ENDPOINT } from "./constants";
 import { InvalidEndpoint } from "./error";
 import { generateOptionsString, parseOptionTokens } from "./image-options";
-import { compact, createUrl, isBase64UrlFormatted } from "./util";
+import { compact, createUrl, isBase64UrlEncoded } from "./util";
 import { generateVisionaryCode, parseVisionaryCode } from "./visionary-code";
 
 import {
@@ -16,7 +16,7 @@ import {
  * @param visionaryCodeOrUrl string which represents a Visionary Code or Visionary URL
  */
 export const parseVisionaryString = (visionaryCodeOrUrl: string): VisionaryImage | null => {
-  const isFormattedAsCode = isBase64UrlFormatted(visionaryCodeOrUrl);
+  const isFormattedAsCode = isBase64UrlEncoded(visionaryCodeOrUrl);
   if (isFormattedAsCode) {
     const fields = parseVisionaryCode(visionaryCodeOrUrl);
     if (fields) {
@@ -107,10 +107,10 @@ const extractUrlParts = (inputUrl: string): VisionaryUrlParts | null => {
       throw new Error("Unrecognized URL");
     }
     const code = pathParts[1].trim();
-    if (!code.length || !isBase64UrlFormatted(code)) {
+    if (!code.length || !isBase64UrlEncoded(code)) {
       throw new Error("URL is not formatted as base64url");
     }
-    // Options defined in URL
+    // Options specified
     if (pathParts.length === 4) {
       const optionTokens = pathParts[2].split(",");
       return {
@@ -118,7 +118,7 @@ const extractUrlParts = (inputUrl: string): VisionaryUrlParts | null => {
         optionTokens,
       };
     }
-    // Options not defined in URL
+    // Options not specified
     if (pathParts.length === 3) {
       return {
         code,


### PR DESCRIPTION
- rename `isBase64UrlFormatted()` to `isBase64UrlEncoded()` for clarity
- rename `fileId` prop to `url` for clarity
- tidy up tests and comments
- minor version bump of this package -> v.1.30
- minor version bumps to dev dependencies (`typescript`, `vite`, `vite-plugin-dts`, `vitest`)