### PR TITLE
V1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 **Visionary URL** is a lightweight Typescript library for generating image URLs with built-in Blurhash placeholders.
 
-![NPM version](https://img.shields.io/npm/v/visionary-url?style=flat-square&color=528987) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/visionary-cloud/visionary-url/.github%2Fworkflows%2Fci-cd-workflow.yml?branch=master&style=flat-square)
-![NPM bundle size](https://img.shields.io/bundlephobia/min/visionary-url?style=flat-square&color=blue)
+![NPM version](https://img.shields.io/npm/v/visionary-url?style=flat-square&color=528987) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/visionary-ux/visionary-url/.github%2Fworkflows%2Fci-cd-workflow.yml?branch=master&style=flat-square)
+![NPM bundle size](https://img.shields.io/bundlephobia/minzip/visionary-url?style=flat-square&color=blue)
+
+## Features
+
+- Generate image URLs with embedded blurhash data, enabling instant image placeholders (via [visionary-image](#))
+- Compatible with browser, Node.js, and worker environments
+- Supports both ES Modules and CommonJS
+- Small footprint, just over 2 kb minzipped
 
 ## Getting started
 
-Install `visionary-url` via npm. Both ES modules and CommonJS modules are supported.
+### Installation
 
 ```bash
 npm install --save visionary-url
@@ -13,58 +20,91 @@ npm install --save visionary-url
 
 ### Generating a Visionary URL
 
+Wrap a public image URL with Visionary data:
+
 ```javascript
 import { generateVisionaryUrl } from "visionary-url";
 
-const url = generateVisionaryUrl({
-  blurhash: "LCDJYN9FxG_M_N%L%M%M4o~ptRIA", // blurhash string
-  blurhashX: 4, // blurhash x components
-  blurhashY: 4, // blurhash y components
-  bcc: "#baccae", // background color code
-  sourceHeight: 1200, // image height
-  sourceWidth: 1600, // image width
-  url: "https://example.cdn/media/gato.jpg", // image URL or file ID
+const visionaryUrl = generateVisionaryUrl({
+  // Blurhash string and number of x, y components
+  blurhash: "LCDJYN9FxG_M_N%L%M%M4o~ptRIA",
+  blurhashX: 4,
+  blurhashY: 4,
+  // Background color code
+  bcc: "#baccae",
+  // Source image dimensions
+  sourceHeight: 1200,
+  sourceWidth: 1600,
+  // Image URL or internal image ID
+  url: "https://example.cdn/media/gato.jpg",
 });
 ```
 
-## How it works
+## URL Structure
 
-A Visionary URL is formatted using 3 or 4 URL segments:
-| | base path | | visionary code | | options (optional) | | filename |
+A Visionary URL path consists of 3 or 4 segments:
+| | Base path | | Visionary Code | | Options (optional) | | Filename |
 | -- | -- | -- | -- | -- | -- | -- | -- |
-| `/` | `image` | `/` | `<visionary code, base64url>` | `/` |`<option tokens>` | `/` | `image.jpg` |
+| `/` | `image` | `/` | `<base64url-encoded Visionary data>` | `/` |`<option tokens>` | `/` | `image.jpg` |
 
-### Example URLs
+### Base path
 
-```
-https://example.cdn/image/aW1hZ2U6MTAwMDEhODAwITYwMA/image.jpg
-https://example.cdn/image/aW1hZ2U6MTAwMDEhODAwITYwMA/4k/image.jpg
-```
+Defaults to "image".
 
-### Visionary code
+### Visionary Code
 
-The **Visionary code** is a base64url'd, exclamation-point separated list of image placeholder data, detailed as the following:
+The `Visionary Code` field is a base64url-encoded string containing the following fields:
 
-| Attribute             | Description                                                  |
-| --------------------- | ------------------------------------------------------------ |
-| Image URL / ID        | Image URL or Visionary file ID (required)                    |
-| Image width           | Used to compute aspect ratio of image placeholder (required) |
-| Image height          | Used to compute aspect ratio of image placeholder (required) |
-| Background color code | Base layer background color code (e.g. `#BACCAE`)            |
-| Blurhash code         | Blurhash string of the image                                 |
-| Blurhash x components | Number of x components the blurhash code represents          |
-| Blurhash y components | Number of y components the blurhash code represents          |
+| Index | Attribute             | Description                                                                    |
+| ----- | --------------------- | ------------------------------------------------------------------------------ |
+| `0`   | Image URL / ID        | Image URL or internal image ID. <br/> **required**                             |
+| `1`   | Image width           | Used for aspect ratio and max-width of image placeholder. <br/> **required**   |
+| `2`   | Image height          | Used for aspect ratio and max-height of image placeholder. <br/> **required**  |
+| `3`   | Background color code | Base layer color (e.g. `#BACCAE`).                                             |
+| `4`   | Blurhash code         | Blurhash string of the image.                                                  |
+| `5`   | Blurhash x components | Number of x components in blurhash.                                            |
+| `6`   | Blurhash y components | Number of y components in blurhash.                                            |
+| `7`   | Alt text              | Alt text to render on the image — optional, but recommended for accessibility. |
 
-### Image options
+> [!NOTE]
+> The first three fields are required to render a properly sized placeholder. The other fields may be omitted.
 
-Image options are optional and are provided as comma separated tokens.
+### Image Options
 
-#### Size token
+Image options may be specified as a set of comma-separated tokens.
 
-One of the following tokens may be included in the options string to specify an image size: `xs`, `sm`, `md`, `lg`, `xl`, `xxl`, `4k`, `5k`
+#### Format tokens
+
+Specify image format: `auto` (default), `avif`, `jpeg`, `webp`.
+
+Format tokens are defined in the `ImageFormatToken` enum in [enum.ts](src/enum.ts).
+
+#### Size tokens
+
+Specify image size: `xs`, `sm`, `md`, `lg`, `xl`, `xxl`, `4k`, `5k`.
+
+Size tokens are defined in the `ImageSizeToken` enum in [enum.ts](src/enum.ts). Size to pixel mapping is defined in the `IMAGE_SIZES` variable in [constants.ts](src/constants.ts).
 
 #### Download token
 
 | token      | description                                                                            |
 | ---------- | -------------------------------------------------------------------------------------- |
-| `download` | Indication for server to return `content-disposition: attachment;` in response headers |
+| `download` | Indication for server to return `content-disposition: attachment` in response headers. |
+
+### Filename
+
+Defaults to `image.jpg`.
+
+Use descriptive filenames (like `great-bamboo-forest-kyoto-japan.jpg`) to improve image discoverability in search.
+
+## FAQ
+
+### What are the benefits of using Visionary URL?
+
+Visionary URLs contain all data necessary to render beautiful image placeholders. This approach eliminates the need for separate API calls to fetch blurhash placeholder data, resulting in faster initial page renders and a smoother visual loading experience for users.
+
+Furthermore, you can use Visionary to update your existing image URL field. No need for data migrations to add blurhash columns in your DB.
+
+### How are fields separated in the Visionary Code
+
+Visionary Code fields are separated with an exclamation `!` before being base64url-encoded. This separator must be a value not used by blurhash/base83. See here for more details: https://github.com/woltapp/blurhash/blob/master/Algorithm.md#base-83

--- a/lib/visionary-url.ts
+++ b/lib/visionary-url.ts
@@ -4,14 +4,10 @@ export { generateVisionaryUrl, parseVisionaryString, parseVisionaryUrl } from ".
 export * from "../src/enum";
 export { parseOptionsString } from "../src/image-options";
 export * from "../src/token";
-export {
-  formatToContentType,
-  isBase64UrlEncoded,
-  suggestedBlurhashComponentDimensions,
-} from "../src/util";
+export { formatToContentType, isBase64UrlEncoded, suggestedBlurhashComponentDimensions } from "../src/util";
 export type {
+  GenerateUrlOptions,
   VisionaryImage,
   VisionaryImageFields,
   VisionaryImageOptions,
-  VisionaryUrlOptions,
 } from "../src/types/visionary.types";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visionary-url",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A lightweight library for generating image URLs with baked-in blurhash placeholders.",
   "type": "module",
   "main": "./dist/visionary-url.cjs",
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/visionary-cloud/visionary-url.git"
+    "url": "git+https://github.com/visionary-ux/visionary-url.git"
   },
   "files": [
     "dist/",
@@ -64,6 +64,7 @@
     "blurhash",
     "image",
     "placeholder",
-    "ux"
+    "ux",
+    "visionary"
   ]
 }

--- a/src/__test__/visionary-url.test.ts
+++ b/src/__test__/visionary-url.test.ts
@@ -16,7 +16,7 @@ const sampleFields: VisionaryImageFields = {
 };
 
 const sampleUrl =
-  "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQQ/strawberries.jpg";
+  "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQQ/strawberries.jpg";
 
 describe("visionary-url", () => {
   describe(parseVisionaryUrl.name, () => {
@@ -29,7 +29,7 @@ describe("visionary-url", () => {
 
     test("parses a Visionary URL with options", () => {
       const urlWithOptions =
-        "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQQ/4k,avif/strawberries.jpg";
+        "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQQ/4k,avif/strawberries.jpg";
 
       const { fields, options } = parseVisionaryUrl(urlWithOptions)!;
 
@@ -51,7 +51,7 @@ describe("visionary-url", () => {
       const url = generateVisionaryUrl(sampleFields);
 
       const expectedUrl =
-        "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/image.jpg";
+        "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/image.jpg";
 
       expect(url).toBe(expectedUrl);
     });
@@ -73,7 +73,7 @@ describe("visionary-url", () => {
       });
 
       const expectedUrl =
-        "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/download/image.jpg";
+        "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/download/image.jpg";
 
       expect(url).toBe(expectedUrl);
     });
@@ -85,7 +85,7 @@ describe("visionary-url", () => {
       });
 
       const expectedUrl =
-        "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/download,full/image.jpg";
+        "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/download,full/image.jpg";
 
       expect(url).toBe(expectedUrl);
     });
@@ -98,7 +98,7 @@ describe("visionary-url", () => {
       });
 
       const expectedUrl =
-        "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/4k,download/flowers.jpg";
+        "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/4k,download/flowers.jpg";
 
       expect(url).toBe(expectedUrl);
     });
@@ -109,7 +109,7 @@ describe("visionary-url", () => {
       });
 
       const expectedUrl =
-        "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/strawberry-fields-vibrant-red.jpg";
+        "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQSE0ITQ/strawberry-fields-vibrant-red.jpg";
 
       expect(url).toBe(expectedUrl);
     });
@@ -122,7 +122,7 @@ describe("visionary-url", () => {
       });
 
       const expectedUrl =
-        "https://cdn.visionary.cloud/image/aHR0cHM6Ly9pc3Muc3BhY2UvZWFydGguanBnITQwMCEzMDA/image.jpg";
+        "https://link.visionary.cloud/image/aHR0cHM6Ly9pc3Muc3BhY2UvZWFydGguanBnITQwMCEzMDA/image.jpg";
 
       expect(url).toBe(expectedUrl);
     });
@@ -153,7 +153,7 @@ describe("visionary-url", () => {
   describe(parseVisionaryString.name, () => {
     test("parses a Visionary URL", () => {
       const inputString =
-        "https://cdn.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQQ/sm,webp/fruit.jpg";
+        "https://link.visionary.cloud/image/dmI4N3MxITE2MDAhMTIwMCExMTAwNDQhTENESllOOUZ4R19NX04lTCVNJU00b35wdFJJQQ/sm,webp/fruit.jpg";
 
       const { fields, options } = parseVisionaryString(inputString)!;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,10 +7,10 @@ import { VisionaryImageOptions } from "./types/visionary.types";
 export const BASE_BLURHASH_DIMENSIONS = 4;
 
 /**
- * Default CDN base URL.
+ * Default endpoint for generating Visionary URLs
  * - Can be overridden in the `options` field of generateVisionaryUrl()
  */
-export const CDN_ENDPOINT = "https://cdn.visionary.cloud";
+export const DEFAULT_ENDPOINT = "https://link.visionary.cloud";
 
 export const DEFAULT_OPTIONS: VisionaryImageOptions = {
   debug: false,

--- a/src/types/visionary.types.ts
+++ b/src/types/visionary.types.ts
@@ -41,7 +41,7 @@ export interface VisionaryImageFields {
   sourceWidth: number;
 
   /**
-   * Image URL or Visionary File ID
+   * Image URL or internal image identifier
    */
   url: string;
 }
@@ -61,28 +61,21 @@ export interface VisionaryImage {
  */
 export interface VisionaryImageOptions {
   debug?: boolean;
-
   /**
    * Specifies that server should send the file as an attachment download
    * (e.g. content-disposition: attachment)
    */
   download?: boolean;
+  /** Specifies a custom endpoint when `generateVisionaryUrl()` is used */
+  endpoint?: string;
   format?: ImageFormatToken;
   size?: ImageSizeToken;
 }
 
-/**
- * Fields passed to generateVisionaryUrl()
- */
-export interface VisionaryUrlOptions extends VisionaryImageOptions {
-  /**
-   * Specifies a custom endpoint
-   */
-  endpoint?: string;
-
+export interface GenerateUrlOptions extends VisionaryImageOptions {
   /**
    * Specifies a filename for the image URL. Defaults to `image.jpg`.
-   * NOTE: It's recommended to specify a filename as this helps improve discoverability of images by search engines.
+   * @NOTE It's highly recommended to specify a descriptive filename as this helps improve discoverability of images by search engines.
    */
   filename?: string;
 }

--- a/src/visionary-code.ts
+++ b/src/visionary-code.ts
@@ -61,13 +61,17 @@ export const parseVisionaryCode = (code: string): VisionaryImageFields | null =>
   const sourceWidth = Number(widthInput.trim());
   const sourceHeight = Number(heightInput.trim());
   if (isNaN(sourceWidth) || isNaN(sourceHeight) || !sourceWidth || !sourceHeight) {
-    console.error("Cannot parse code, invalid image dimensions: ", widthInput, heightInput);
+    console.error("Cannot parse Visionary Code: invalid image dimensions", widthInput, heightInput);
     return null;
   }
   const blurhashX = Number(bhX) ?? 0;
   const blurhashY = Number(bhY) ?? 0;
   if (blurhashX < 1 || blurhashY < 1) {
-    console.error("Cannot parse code, invalid blurhash x, y component dimensions");
+    console.error(
+      "Cannot parse Visionary Code: invalid blurhash x, y component dimensions",
+      blurhashX,
+      blurhashY
+    );
     return null;
   }
   const fields: VisionaryImageFields = {

--- a/src/visionary-code.ts
+++ b/src/visionary-code.ts
@@ -48,7 +48,7 @@ export const parseVisionaryCode = (code: string): VisionaryImageFields | null =>
     return null;
   }
   const imageData = imageDataStr.split(V_CODE_SEPARATOR);
-  // codes must contain at a minimum: url, width, height
+  // Visionary codes must contain at a minimum: url, width, height
   if (imageData.length < 3) {
     return null;
   }

--- a/src/visionary-url.ts
+++ b/src/visionary-url.ts
@@ -1,4 +1,4 @@
-import { CDN_ENDPOINT } from "./constants";
+import { DEFAULT_ENDPOINT } from "./constants";
 import { InvalidEndpoint } from "./error";
 import { generateOptionsString, parseOptionTokens } from "./image-options";
 import { compact, createUrl, isBase64UrlEncoded } from "./util";
@@ -81,7 +81,7 @@ export const generateVisionaryUrl = (
     }
   }
   if (!urlEndpoint) {
-    urlEndpoint = createUrl(CDN_ENDPOINT) as URL;
+    urlEndpoint = createUrl(DEFAULT_ENDPOINT) as URL;
   }
   const urlParts = [urlEndpoint.origin, "image", visionaryCode];
   const optionsString = options ? generateOptionsString(options) : null;

--- a/src/visionary-url.ts
+++ b/src/visionary-url.ts
@@ -5,7 +5,7 @@ import { compact, createUrl, isBase64UrlEncoded } from "./util";
 import { generateVisionaryCode, parseVisionaryCode } from "./visionary-code";
 
 import {
-  VisionaryUrlOptions,
+  GenerateUrlOptions,
   VisionaryImage,
   VisionaryImageFields,
   VisionaryUrlParts,
@@ -64,7 +64,7 @@ export const parseVisionaryUrl = (url: string): VisionaryImage | null => {
 
 export const generateVisionaryUrl = (
   fields: VisionaryImageFields,
-  options?: VisionaryUrlOptions
+  options?: GenerateUrlOptions
 ): string | null => {
   const visionaryCode = generateVisionaryCode(fields);
   if (visionaryCode instanceof Error) {


### PR DESCRIPTION
- update README
- update default endpoint when generating URLs
- rename types for readability (`VisionaryUrlOptions` -> `GenerateUrlOptions`)
- more readable error messaging
- patch version bump `v1.3.0` -> `v1.3.1`