### PR TITLE
feat: add `follow` option for server-side redirect handling

### DIFF
--- a/src/__test__/image-options.test.ts
+++ b/src/__test__/image-options.test.ts
@@ -5,12 +5,21 @@ import { generateOptionsString, parseOptionsString } from "../image-options";
 import { VisionaryImageOptions } from "../types/visionary.types";
 
 describe(parseOptionsString.name, () => {
+  test("options defaults", () => {
+    const parsedOptions = parseOptionsString("");
+
+    expect(parsedOptions.debug).toBeFalsy();
+    expect(parsedOptions.download).toBeFalsy();
+    expect(parsedOptions.follow).toBeFalsy();
+  });
+
   test("parses an options string with size and format specified", () => {
-    const optionsString = "xs,f_auto";
+    const optionsString = "auto,xs";
 
     const parsedOptions = parseOptionsString(optionsString);
 
     expect(parsedOptions.size).toBe(ImageSizeToken.xs);
+    expect(parsedOptions.format).toBe(ImageFormatToken.AUTO);
   });
 
   test("tests a size token (lg)", () => {
@@ -37,6 +46,14 @@ describe(parseOptionsString.name, () => {
 
     expect(parsedOptions.download).toBe(true);
     expect(parsedOptions.size).toBe(ImageSizeToken["4k"]);
+  });
+
+  test("parses an options string with follow set", () => {
+    const optionsString = "4k,follow";
+
+    const parsedOptions = parseOptionsString(optionsString);
+
+    expect(parsedOptions.follow).toBe(true);
   });
 
   test("parses an options string with format set", () => {

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -23,4 +23,5 @@ export enum ImageSizeToken {
 export enum UrlOptionToken {
   DEBUG = "debug",
   DOWNLOAD = "download",
+  FOLLOW = "follow",
 }

--- a/src/image-options.ts
+++ b/src/image-options.ts
@@ -1,5 +1,11 @@
 import { ImageFormatToken, ImageSizeToken, UrlOptionToken } from "./enum";
-import { isDebugToken, isDownloadToken, isImageFormatToken, isImageSizeToken } from "./token";
+import {
+  isDebugToken,
+  isDownloadToken,
+  isFollowToken,
+  isImageFormatToken,
+  isImageSizeToken,
+} from "./token";
 import { VisionaryImageOptions } from "./types/visionary.types";
 
 export const parseOptionTokens = (optionTokens: string[] = []): VisionaryImageOptions => {
@@ -11,6 +17,8 @@ export const parseOptionTokens = (optionTokens: string[] = []): VisionaryImageOp
       returnOptions.debug = true;
     } else if (isDownloadToken(token)) {
       returnOptions.download = true;
+    } else if (isFollowToken(token)) {
+      returnOptions.follow = true;
     } else if (isImageFormatToken(token)) {
       returnOptions.format = token;
     }
@@ -28,6 +36,9 @@ export const generateOptionsString = (options: VisionaryImageOptions): string | 
   }
   if (options.download) {
     tokenArr.push(UrlOptionToken.DOWNLOAD);
+  }
+  if (options.follow) {
+    tokenArr.push(UrlOptionToken.FOLLOW);
   }
   if (options.format) {
     if (options.format !== ImageFormatToken.AUTO) {

--- a/src/token.ts
+++ b/src/token.ts
@@ -4,6 +4,8 @@ export const isDebugToken = (token: string) => token === UrlOptionToken.DEBUG;
 
 export const isDownloadToken = (token: string) => token === UrlOptionToken.DOWNLOAD;
 
+export const isFollowToken = (token: string) => token === UrlOptionToken.FOLLOW;
+
 export const isImageFormatToken = (format: string): format is ImageFormatToken =>
   Object.values(ImageFormatToken).includes(format as ImageFormatToken);
 

--- a/src/types/visionary.types.ts
+++ b/src/types/visionary.types.ts
@@ -68,6 +68,7 @@ export interface VisionaryImageOptions {
   download?: boolean;
   /** Specifies a custom endpoint when `generateVisionaryUrl()` is used */
   endpoint?: string;
+  follow?: boolean;
   format?: ImageFormatToken;
   size?: ImageSizeToken;
 }


### PR DESCRIPTION
- added a new options token `follow` 
- `follow` instructs the server to follow redirects (for whitelisted domains) when `url` points to an external URL 
